### PR TITLE
[vibe] 把XposedAPI声明为82版 规避最新LSPosed 101不兼容100模块问题

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "me.bingyue.fuckbiliads"
         minSdk 27
         targetSdk 34
-        versionCode 8
-        versionName "4.2"
+        versionCode 9
+        versionName "4.3"
 
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:value="去除b站开屏广告" />
     <meta-data
         android:name="xposedminversion"
-        android:value="100" />
+        android:value="82" />
     <meta-data
         android:name="xposedscope"
         android:resource="@array/xposedscope" />

--- a/app/src/main/java/me/bingyue/fuckbiliads/MainHook.java
+++ b/app/src/main/java/me/bingyue/fuckbiliads/MainHook.java
@@ -1,17 +1,29 @@
 package me.bingyue.fuckbiliads;
 
-
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodReplacement;
+import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
-
-
 public class MainHook implements IXposedHookLoadPackage {
+    private static final String TAG = "FuckBiliAds";
+    private static final String TARGET_PACKAGE = "tv.danmaku.bili";
+    private static final String TARGET_CLASS = "tv.danmaku.bili.ui.splash.ad.model.Splash";
+    private static final String TARGET_METHOD = "isValid";
+
     @Override
-    public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
-        if (!lpparam.packageName.equals("tv.danmaku.bili")) return;
-        XposedHelpers.findAndHookMethod("tv.danmaku.bili.ui.splash.ad.model.Splash", lpparam.classLoader, "isValid", XC_MethodReplacement.returnConstant(false));
+    public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) {
+        if (!TARGET_PACKAGE.equals(lpparam.packageName)) return;
+        try {
+            XposedHelpers.findAndHookMethod(
+                    TARGET_CLASS,
+                    lpparam.classLoader,
+                    TARGET_METHOD,
+                    XC_MethodReplacement.returnConstant(false)
+            );
+        } catch (Throwable t) {
+            XposedBridge.log("[" + TAG + "] hook failed: " + t);
+        }
     }
 }


### PR DESCRIPTION
- Align xposedminversion with legacy API 82 (was 100, mismatched the XposedBridgeApi-82 dependency declared in libs.versions.toml).
- Wrap the Splash#isValid hook in try/catch and route failures through XposedBridge.log so future Bilibili refactors stop the hook quietly instead of crashing the host app.
- Extract target package/class/method to constants for readability.
- Bump versionCode to 9 / versionName to 4.3.